### PR TITLE
[EX-325] M1 api response always for validateWarranty always looks for…

### DIFF
--- a/app/code/local/Extend/Warranty/Helper/Api.php
+++ b/app/code/local/Extend/Warranty/Helper/Api.php
@@ -30,8 +30,9 @@ class Extend_Warranty_Helper_Api extends Mage_Core_Helper_Abstract
 
         if (empty($errors)) {
             $offerInformation = $this->getOfferInformation($warrantyData['product']);
-            if (isset($offerInformation['base'])) {
-                $baseOfferInformation = $offerInformation['base'];
+            $recommendedPlans = isset($offerInformation['recommended']) ? $offerInformation['recommended'] : '';
+            if (isset($offerInformation[$recommendedPlans])) {
+                $baseOfferInformation = $offerInformation[$recommendedPlans];
                 $offerIds = array_column($baseOfferInformation, 'id');
                 if (in_array($warrantyData['planId'], $offerIds)) {
                     foreach ($baseOfferInformation as $offer) {


### PR DESCRIPTION
… "base", rather than "recommended/adh", making the api response always fail