### PR TITLE
[EX-438] [M1] Define Magento Configuration Settings to Reserved "Inte…

### DIFF
--- a/app/design/frontend/base/default/layout/extend_warranty.xml
+++ b/app/design/frontend/base/default/layout/extend_warranty.xml
@@ -19,8 +19,8 @@
         </reference>
         <reference name="content">
             <block type="warranty/lead" name="extend.warranty.lead" after="-" template="warranty/lead-warranty.phtml"/>
+            <block type="warranty/installation" name="warranty_extend_intallation" template="warranty/installation.phtml"/>
         </reference>
-        <update handle="extend_warranty_installation"/>
     </cms_index_index>
 
     <catalog_product_view>


### PR DESCRIPTION
…gration" Namespace on Extend object

- fix for cms_index_index layout update, handle didn't work as content reference was already used in update